### PR TITLE
feature - support cpu inference and training

### DIFF
--- a/evaluate_images.py
+++ b/evaluate_images.py
@@ -31,10 +31,13 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
     args = parse_args()
 
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    logging.info(f'running inference on {device}')
+
     logging.info(f'loading AgeRegressionModel from {args.model}')
     model = AgeRegressionModel()
-    model.load_state_dict(torch.load(args.model))
-    model.cuda().eval()
+    model.load_state_dict(torch.load(args.model, map_location=device))
+    model.to(device).eval()
 
     logging.info(f'evaluating images from {args.images}')
     image_dir = pathlib.Path(args.images)
@@ -45,7 +48,7 @@ if __name__ == '__main__':
         image = image_transform(image_file)
 
         with torch.no_grad():
-            image = image.cuda().unsqueeze(0)
+            image = image.to(device).unsqueeze(0)
             pred_age = model(image)
 
             image = image[0]

--- a/train.py
+++ b/train.py
@@ -39,6 +39,9 @@ if __name__ == '__main__':
     args = parse_args()
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
 
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    logging.info(f'running training on {device}')
+
     logging.info('creating dataset and data loaders')
     train_dataset = AllAgeFacesDataset(args.train, use_augmentation=True)
     val_dataset = AllAgeFacesDataset(args.val, use_augmentation=False)
@@ -51,7 +54,7 @@ if __name__ == '__main__':
     )
 
     logging.info(f'creating model and optimizer with initial lr of {args.initial_lr}')
-    model = AgeRegressionModel().cuda()
+    model = AgeRegressionModel().to(device)
 
     optimizer = optim.Adam(params=model.parameters(), lr=args.initial_lr)
 
@@ -61,7 +64,7 @@ if __name__ == '__main__':
         model=model,
         optimizer=optimizer,
         loss_fn=nn.MSELoss(),
-        device='cuda',
+        device=device,
         non_blocking=True,
     )
 
@@ -72,7 +75,7 @@ if __name__ == '__main__':
             'mse': metrics.MeanSquaredError(),
             'mae': metrics.MeanAbsoluteError(),
         },
-        device='cuda',
+        device=device,
         non_blocking=True,
     )
 


### PR DESCRIPTION
In this PR we add support for CPU training and inference; this required minor modifications to `train` and `evaluate_images`. To test this PR, both scripts were run with `CUDA_VISIBLE_DEVICES=-1` so they weren't visible when the application ran. Also checked this by running `nvidia-smi` in another window.