### PR TITLE
age regression - update enviroment to support 30-series GPus

### DIFF
--- a/enviroment.yml
+++ b/enviroment.yml
@@ -3,12 +3,12 @@ channels:
   - pytorch
   - conda-forge
 dependencies:
-  - python==3.7.5
+  - python>=3.7
   - pip
-  - pytorch==1.5
-  - torchvision==0.6.0
-  - cudatoolkit=10.1
-  - numpy==1.16.3
+  - pytorch
+  - torchvision
+  - cudatoolkit>=11.1
+  - numpy
   - pip:
     - pytorch-ignite
     - tensorboard


### PR DESCRIPTION
In this PR we upgrade pytorch and CUDA versions to support 30-series cards. We also remove the hard dependency on pytorch and hopefully we can live at HEAD.